### PR TITLE
Fix handling of sort option closures.

### DIFF
--- a/src/services/SearchTypes.php
+++ b/src/services/SearchTypes.php
@@ -248,7 +248,14 @@ class SearchTypes extends Component
 
                 if (is_callable($orderBy)) {
                     $attribute = function($dir) use ($orderBy) {
-                        return str_replace('field_', '', $orderBy($dir));
+                        $var = $orderBy($dir);
+
+                        if (is_array($var)) {
+                            return str_replace('field_', '', $var);
+                        }
+
+                        // yii/db/ExpressionInterface
+                        return $var;
                     };
                 }
                 else if (is_string($orderBy)) {

--- a/src/services/SearchTypes.php
+++ b/src/services/SearchTypes.php
@@ -244,7 +244,19 @@ class SearchTypes extends Component
                     $defaultSortOptions[$count]['orderBy'] = $sortOption['orderBy'];
                 }
 
-                $attribute = str_replace('field_', '', $sortOption['orderBy']) ?? null;
+                $orderBy = $sortOption['orderBy'];
+
+                if (is_callable($orderBy)) {
+                    $attribute = function($dir) use ($orderBy) {
+                        return str_replace('field_', '', $orderBy($dir));
+                    };
+                }
+                else if (is_string($orderBy)) {
+                    $attribute = str_replace('field_', '', $orderBy);
+                }
+                else {
+                    $attribute = null;
+                }
 
                 $sortOptions[] = $attribute;
             }


### PR DESCRIPTION
SearchTypes::getSortOptions assumed that orderBy is always a string and breaks otherwise.

As documented in craft/base/ElementInterface:

> `orderBy` – An array, comma-delimited string, or a callback function that defines the columns to order the query by. If set to a callback function, the function will be passed a single argument, `$dir`, set to either `SORT_ASC` or `SORT_DESC`, and it should return an array of column names or an [[\yii\db\ExpressionInterface]] object.

Yeah so we couldn't even create a 'search setup' without it breaking. So I just wrapped it up.

In testing the admin interface now works. I haven't gone much further than that.